### PR TITLE
added README naming convention table

### DIFF
--- a/contribution-workflow.md
+++ b/contribution-workflow.md
@@ -91,6 +91,12 @@ Examples for possible branch names:
 * hoisting/enhance/structure-changed
 * contribution-workflow/new
 
+|Type of correction|Branch name|
+|----------------|:-------------:|
+|Correcting grammatical mistakes or typos|*/correct*|
+|Reorganising or clarifying material|*/enhance*|
+|Adding new sections|*/add*|
+
 This kind of naming convention does not only help to see what branches are used for. It also impacts the review process because a simple typo correction can be approved and merged more quickly than a larger change.
 
 _NOTE: This naming convention makes sense for this repository because changes should be made to each README file on separate branches. For other projects you might want to choose different naming conventions._
@@ -140,16 +146,16 @@ On the repository you will go through the following steps to issue your pull req
 This is quite straight-forward. You can see the steps in more detail on [Github help](https://help.github.com/articles/creating-a-pull-request/).
 
 Note: If you find you have additional commits to push on the same file after completing the above steps, you may replicate part of the steps above and push additional commits to the existing pull request.
-To do so, start by setting the default upstream branch as before, then simply follow Step 2 again to stage, commit, and push the ADDITIONAL changes. If done correctly, the additional commits should be visible within your existing pull request. 
+To do so, start by setting the default upstream branch as before, then simply follow Step 2 again to stage, commit, and push the ADDITIONAL changes. If done correctly, the additional commits should be visible within your existing pull request.
 
 #### Assign the pull request
 
 If possible, always assign your pull request to a specific person. That makes sure someone gets notified to look at it.
-The assigned person should either be the original creator of the README file or someone who recently contributed a lot. 
+The assigned person should either be the original creator of the README file or someone who recently contributed a lot.
 To check who you should assign your request to, go back to the original file in the repository. To the right side, under "Contributors"
 you will find the "Blame" button. This reveals the change list, sorted by date in descending order, with corresponding usernames.
 
-To assign your pull request to an individual, go back to the page for your specific pull request and on the right side of the page you will 
+To assign your pull request to an individual, go back to the page for your specific pull request and on the right side of the page you will
 see "Assignee" next to a grey gear. Click the gear, and search for the user from the previous step.
 
 For completely new README files you created, you don't have to assign anyone. Instead just post the link in the [README Gitter channel](https://gitter.im/codingforeveryone/READMEs?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge).


### PR DESCRIPTION
I've just copied the naming convention table from the README to the contribution-workflow document as I find myself wanting to check the table when I look at the contribution workflow.
