### PR TITLE
Add a link to the CSS centering article

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,6 +35,7 @@
 
 * [HTML and CSS](/gitbook-chapter-headers/html-css.md)
     * [Choosing a CSS Framework](/html-css/choosing-a-css-framework.md)
+    * [CSS Centering](/html-css/css-centering.md)
     * [Document Object Model](/html-css/document-object-model.md)
     * [Manipulating Inline Styles](/html-css/manipulating-inline-styles.md)
     * [Laying Out Content with Flexbox](/html-css/laying-out-content-with-flexbox.md)


### PR DESCRIPTION
Add a link to the existing [CSS centering article](https://github.com/codingforeveryone/READMEs/blob/master/html-css/css-centering.md) so that it shows up in the table of contents of the [GitBook](https://foundersandcoders.gitbooks.io/codingforeveryone/content/gitbook-chapter-headers/html-css.html)