### PR TITLE
Add Best Practices Section for Random Tests

### DIFF
--- a/codewars/writing-your-own-kata.md
+++ b/codewars/writing-your-own-kata.md
@@ -1,4 +1,5 @@
 # Writing your own kata – a step by step guide
+
 Writing Codewars kata is hard. You’re producing something that you’re hoping will be fun and challenging for a community that while supportive, has high expectations for your work. This guide is a roadmap for beginners who are familiar with the Codewars framework but don't know where to start when it comes to writing their own kata. Writing a kata can be quite a long and involved process so don't try to read this guide all in one go. Just dip into the relevant bits when you're at each stage. All example code is in the [Founders & Coders](http://www.foundersandcoders.com/) language of choice, Javascript.
 ## Step 1 – Come up with an idea
 According to Wikipedia, _“Kata (型 or 形 literally: "form"), a Japanese word, are the detailed choreographed patterns of movements practised in many traditional Japanese arts, most commonly known for their presence in the martial arts, such as aikido, judo, kendo and karate.”_


### PR DESCRIPTION
This pull request adds a section in the markdown file regarding writing random test cases for beginners on Codewars.  This extra section is on Best Practices and explains to the reader how to further prevent cheats and/or unexpected results when writing random tests.  The author of this pull request has spent over a year on the Codewars platform and has authored a total of 82 Kata at the time of writing, over 75% of which were highly successful so hopefully this addition to the documentation can further guide beginners on how to write excellent random tests on the first try.  *If needs be*, I could instead move the new content that I just added into another file named something like `random-tests-for-advanced-kata-authors.md` instead of adding the content directly to the existing Markdown file.  I’ve spent the past hour adding the content mentioned so it would be great if it was accepted and merged into the official Repo, thanks :smile: